### PR TITLE
modify type image-cache type and add SVGA

### DIFF
--- a/templates/workbox/sw.js
+++ b/templates/workbox/sw.js
@@ -35,15 +35,17 @@ registerRoute(
   })
 )
 
-// Cache images with a Cache First strategy
+// Demonstrates a custom cache name for a route.
+// https://github.com/GoogleChrome/workbox/blob/63ea2ca52e7278411a71520f48bd9cf700694edd/demos/src/workbox-sw/sw.js
 registerRoute(
-  ({ request }) => request.destination === 'image',
-  new CacheFirst({
-    cacheName: 'images',
+  new RegExp('.*\\.(?:png|jpg|jpeg|svg|gif|svga)'),
+  new workbox.strategies.CacheFirst({
+    cacheName: 'image-cache',
     plugins: [
+      // Ensure that only requests that result in a 200 status are cached
       new CacheableResponsePlugin({ statuses: [200] }),
       // 50 entries max, 30 days max
       new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 * 30 })
-    ]
-  })
-)
+    ],
+  }),
+);


### PR DESCRIPTION
link: https://github.com/GoogleChrome/workbox/blob/63ea2ca52e7278411a71520f48bd9cf700694edd/demos/src/workbox-sw/sw.js
befor: new RegExp('.*\\.(?:png|jpg|jpeg|svg|gif)')
after: new RegExp('.*\\.(?:png|jpg|jpeg|svg|gif|svga)')