### PR TITLE
chore: add key to favicon `link` tags

### DIFF
--- a/src/parts/meta/index.ts
+++ b/src/parts/meta/index.ts
@@ -37,8 +37,8 @@ export default (pwa: PWAContext) => {
 
     // Shortcut icon
     if (options.favicon) {
-      head.link.push({ rel: 'shortcut icon', href: iconSmall.src })
-      head.link.push({ rel: 'apple-touch-icon', href: iconBig.src, sizes: iconBig.sizes })
+      head.link.push({ rel: 'icon', href: iconSmall.src, key: 'favicon' })
+      head.link.push({ rel: 'apple-touch-icon', href: iconBig.src, sizes: iconBig.sizes, key: 'favicon-apple' })
     }
   }
 


### PR DESCRIPTION
Resolves #60 

Also removed `shortcut` as it is not advised, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)