### PR TITLE
feat: add runtime config support for swUrl

### DIFF
--- a/src/runtime/nitro-plugin.ts
+++ b/src/runtime/nitro-plugin.ts
@@ -4,11 +4,15 @@ import { useRuntimeConfig } from '#imports'
 
 export default <NitroAppPlugin> function (nitro) {
   nitro.hooks.hook('render:html', (htmlContext) => {
+    const config = useRuntimeConfig()
+    const baseUrl = config.baseURL
+    const swUrl = config?.pwa?.workbox?.swUrl ?? 'sw.js'
+
     htmlContext.head.push(
       [
         '<script>',
         'if (\'serviceWorker\' in navigator) {',
-        `  window.addEventListener('load', () => navigator.serviceWorker.register('${joinURL(useRuntimeConfig().app.baseURL, 'sw.js')}'))`,
+        `  window.addEventListener('load', () => navigator.serviceWorker.register('${joinURL(baseUrl, swUrl)}'))`,
         '}',
         '</script>',
       ].join('\n'),


### PR DESCRIPTION
My attempt at fixing my issue described in #72

This makes it possible to change the swUrl and add query parameters by setting it in `runtimeConfig` like so:
```ts
runtimeConfig: {
    pwa: {
        workbox: {
            swUrl: `/sw.js?${queryParams}`
        }
    }
}
```

This may not be an optimal solution but it works, please let me know if a different approach is preferred.