### PR TITLE
feat: add manifest meta crossorigin attribute

### DIFF
--- a/src/parts/manifest/index.ts
+++ b/src/parts/manifest/index.ts
@@ -8,8 +8,9 @@ export default (pwa: PWAContext) => {
     return
 
   const nuxt = useNuxt()
+  const { crossorigin, ...manifest } = pwa.manifest
 
-  nuxt.options.runtimeConfig.public.pwaManifest = pwa.manifest
+  nuxt.options.runtimeConfig.public.pwaManifest = manifest
 
   if (nuxt.options.ssr) {
     addServerHandler({
@@ -20,7 +21,7 @@ export default (pwa: PWAContext) => {
   else {
     addTemplate({
       filename: 'manifest.json',
-      getContents: () => JSON.stringify(pwa.manifest),
+      getContents: () => JSON.stringify(manifest),
       dst: join(pwa._buildDir, 'manifest.json'),
       write: true,
     })
@@ -29,5 +30,6 @@ export default (pwa: PWAContext) => {
   pwa._manifestMeta = {
     rel: 'manifest',
     href: joinURL(nuxt.options.app.baseURL, 'manifest.json'),
+    crossorigin,
   }
 }

--- a/src/parts/manifest/types.ts
+++ b/src/parts/manifest/types.ts
@@ -73,4 +73,9 @@ export interface ManifestOptions {
   prefer_related_applications?: boolean
   share_target?: ManifestShareTarget
   protocol_handlers?: ManifestProtocolHandler[]
+  /**
+   * Set meta crossorigin attribute
+   * @see https://web.dev/add-manifest/#link-manifest
+   */
+  crossorigin?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface PWAOptions {
 export interface PWAContext extends PWAOptions {
   _buildDir: string
   _buildAssetsDir: string
-  _manifestMeta?: { rel: 'manifest'; href: string }
+  _manifestMeta?: { rel: 'manifest'; href: string; crossorigin?: string }
   _splashMetas?: Array<{ rel: 'apple-touch-startup-image'; href: string; media: string }>
   _resolver: Resolver
 }


### PR DESCRIPTION
Add the ability to add meta crossorigin attribute as the old nuxt/pwa module

links:
- https://pwa.nuxtjs.org/workbox/#basic-auth
- https://web.dev/add-manifest/#link-manifest

fix #57 