### PR TITLE
fix(meta): avoid meta duplication

### DIFF
--- a/src/parts/meta/index.ts
+++ b/src/parts/meta/index.ts
@@ -8,11 +8,11 @@ type NuxtAppHead = Required<MetaObject>
 const isUrl = (path: string) => /^https?:/.test(path)
 
 function addMeta (head: NuxtAppHead, name: string, content: string | number | boolean) {
-  head.meta.push({ hid: name, name, content })
+  head.meta.push({ name, content })
 }
 
 function addMetaProperty (head: NuxtAppHead, property: string, content: string | number | boolean) {
-  head.meta.push({ hid: property, property, content })
+  head.meta.push({ property, content })
 }
 
 export default (pwa: PWAContext) => {


### PR DESCRIPTION
Resolves #70

> I'd recommend not using `hid` or `key` for deduping. All meta tags will be deduped automatically for you. This also allows users to override them easily.

> You can read further about the logic here: https://unhead.harlanzw.com/guide/guides/handling-duplicates

Useful to note that the `key` usage on `<link>` entries should stay